### PR TITLE
Call type_string() from dbt core

### DIFF
--- a/jaffle_shop/macros/sensitive/hash_of_column.sql
+++ b/jaffle_shop/macros/sensitive/hash_of_column.sql
@@ -3,7 +3,7 @@
     SHA2(
         TRIM(
             LOWER(
-                CAST({{ column|lower }} AS {{ dbt_utils.type_string() }})
+                CAST({{ column|lower }} AS {{ type_string() }})
                 || '{{ jaffle_shop.get_salt(column|lower) }}'
             )
         ),


### PR DESCRIPTION
This macro [was moved to dbt-core](https://github.com/dbt-labs/dbt-utils/issues/720).